### PR TITLE
Use UTF-8 default and support numbers

### DIFF
--- a/houdini/crypto.py
+++ b/houdini/crypto.py
@@ -6,7 +6,11 @@ class Crypto:
 
     @staticmethod
     def hash(undigested):
-        return md5(str(undigested).encode('utf-8')).hexdigest()
+        if type(undigested) == str:
+            undigested = undigested.encode('utf-8')
+        elif type(undigested) == int:
+            undigested = str(undigested).encode('utf-8')
+        return md5(undigested).hexdigest()
 
     @staticmethod
     def generate_random_key():

--- a/houdini/crypto.py
+++ b/houdini/crypto.py
@@ -6,9 +6,9 @@ class Crypto:
 
     @staticmethod
     def hash(undigested):
-        if type(undigested) == str:
-            undigested = undigested.encode('utf-8')
-        return hashlib.md5(undigested).hexdigest()
+        if type(undigested) == int:
+            undigested = str(undigested)
+        return hashlib.md5(undigested.encode('utf-8')).hexdigest()
 
     @staticmethod
     def generate_random_key():

--- a/houdini/crypto.py
+++ b/houdini/crypto.py
@@ -1,18 +1,16 @@
-import hashlib
-import secrets
+from hashlib import md5
+from secrets import token_hex
 
 
 class Crypto:
 
     @staticmethod
     def hash(undigested):
-        if type(undigested) == int:
-            undigested = str(undigested)
-        return hashlib.md5(undigested.encode('utf-8')).hexdigest()
+        return md5(str(undigested).encode('utf-8')).hexdigest()
 
     @staticmethod
     def generate_random_key():
-        return secrets.token_hex(8)
+        return token_hex(8)
 
     @staticmethod
     def encrypt_password(password, digest=True):


### PR DESCRIPTION
hash() will always expect a string, so standardizing UTF-8 is a must. Also in this PR we support numbers to be hashed.