### PR TITLE
Fix `client_type` assignment when running with --single-client-mode

### DIFF
--- a/houdini/handlers/login/__init__.py
+++ b/houdini/handlers/login/__init__.py
@@ -14,7 +14,7 @@ async def handle_version_check(p, version: VersionChkConverter):
         elif p.server.config.vanilla_version == version:
             p.client_type = ClientType.Vanilla
     elif p.server.config.default_version == version:
-        p.client_type = p.server.config.default_version
+        p.client_type = p.server.config.default_client
 
     if p.client_type is None:
         await p.send_xml({'body': {'action': 'apiKO', 'r': '0'}})


### PR DESCRIPTION
Currently assigns client type to the default version config option. This is incorrect, it should instead be set to a client type.

This issue prevents logging in to world server when in this mode.